### PR TITLE
[PR] PartyListView 사진 데이터 관련 이슈 수정

### DIFF
--- a/MC2-OneShot/Presentation/View/PartyListView.swift
+++ b/MC2-OneShot/Presentation/View/PartyListView.swift
@@ -87,6 +87,9 @@ struct StepCell: View {
     var index: Int
     var step: Step
     
+    @State private var visibleMediaIndex = 0
+    @State private var captureDates: [Date] = []
+    
     var body: some View {
         VStack(spacing: 0) {
             HStack {
@@ -102,7 +105,7 @@ struct StepCell: View {
                     }
                     
                     HStack(spacing: 0) {
-                        Text(step.mediaList[0].captureDate.yearMonthDayNoSpace)
+                        Text(captureDates.isEmpty ? "" : captureDates[visibleMediaIndex].yearMonthDayNoSpace)
                             .pretendard(.regular, 14)
                             .foregroundStyle(.shotCE)
                         
@@ -112,7 +115,7 @@ struct StepCell: View {
                             .cornerRadius(10)
                             .padding(.horizontal, 6)
                         
-                        Text(step.mediaList[0].captureDate.aHourMinute)
+                        Text(captureDates.isEmpty ? "" : captureDates[visibleMediaIndex].aHourMinute)
                             .pretendard(.regular, 14)
                             .foregroundStyle(.shotCE)
                     }
@@ -130,8 +133,7 @@ struct StepCell: View {
                             .pretendard(.semiBold, 16)
                             .foregroundStyle(.shotC6)
                     }
-                }
-                )
+                })
             }
             
             ScrollView(.horizontal, showsIndicators: false) {
@@ -154,6 +156,12 @@ struct StepCell: View {
                                 .cornerRadius(50)
                                 .padding(.top, 15)
                                 .padding(.trailing, 20)
+                                .onAppear {
+                                    captureDates.append(media.captureDate)
+                                }
+                        }
+                        .onAppear {
+                            visibleMediaIndex = index
                         }
                     }
                 }


### PR DESCRIPTION
## Description
PartyList 이미지 데이터 오래된 순서대로 정렬되고, 같은 Step 안에서 사진이 스크롤 될 때마다 시간도 찍은 시간으로 바뀌도록 했습니다-!

## Screenshot
https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M10-Sandwich/assets/69234788/9dfedc21-1890-4e96-98a7-02b63cfaab10

## Issue
- Resolved: #72