### PR TITLE
[PR] 카메라 zoom 기능 추가

### DIFF
--- a/MC2-OneShot.xcodeproj/project.pbxproj
+++ b/MC2-OneShot.xcodeproj/project.pbxproj
@@ -654,7 +654,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MC2-OneShot/Preview Content\"";
-				DEVELOPMENT_TEAM = 9XG4S4XZWN;
+				DEVELOPMENT_TEAM = 8U8S6CBZ9D;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "MC2-OneShot/App/Info.plist";
@@ -672,7 +672,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.1.3;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.sandwich.ADA.MC2.OneShot-thinkyside";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sandwich.MC2-OneShot-jongchang";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -692,7 +692,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MC2-OneShot/Preview Content\"";
-				DEVELOPMENT_TEAM = 9XG4S4XZWN;
+				DEVELOPMENT_TEAM = 8U8S6CBZ9D;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "MC2-OneShot/App/Info.plist";
@@ -710,7 +710,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.1.3;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.sandwich.ADA.MC2.OneShot-thinkyside";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sandwich.MC2-OneShot-jongchang";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/MC2-OneShot/Data/Service/CameraService.swift
+++ b/MC2-OneShot/Data/Service/CameraService.swift
@@ -169,9 +169,16 @@ extension CameraService {
     }
     
     /// 줌 배율을 조절합니다.
-    func zoom(factor: CGFloat) {
-        let zoomFactor = factor < 1 ? 1 : factor
+    func zoom(currentZoomFactor: CGFloat, delta: CGFloat) -> CGFloat {
         let device = input.device
+        
+        // 하드웨어 최대 줌 배율
+        // let maxZoomFactor = device.activeFormat.videoMaxZoomFactor
+        
+        let maxZoomFactor : CGFloat = 5
+        
+        let newScale = min(max(currentZoomFactor * delta, 1), maxZoomFactor)
+        let zoomFactor = newScale < 1 ? 1 : newScale
         
         do {
             try device.lockForConfiguration()
@@ -181,6 +188,8 @@ extension CameraService {
         catch {
             print(error.localizedDescription)
         }
+        
+        return newScale
     }
     
     /// 줌 배율을 초기화합니다.

--- a/MC2-OneShot/Data/Service/CameraService.swift
+++ b/MC2-OneShot/Data/Service/CameraService.swift
@@ -167,6 +167,28 @@ extension CameraService {
             }
         }
     }
+    
+    /// 줌 배율을 조절합니다.
+    func zoom(factor: CGFloat) {
+        let zoomFactor = factor < 1 ? 1 : factor
+        let device = input.device
+        
+        do {
+            try device.lockForConfiguration()
+            device.videoZoomFactor = zoomFactor
+            device.unlockForConfiguration()
+        }
+        catch {
+            print(error.localizedDescription)
+        }
+    }
+    
+    /// 줌 배율을 초기화합니다.
+    func zoomInitialize() {
+        
+    }
+    
+    
 }
 
 // MARK: - AVCaptureSession 구현

--- a/MC2-OneShot/Data/Service/CameraService.swift
+++ b/MC2-OneShot/Data/Service/CameraService.swift
@@ -192,12 +192,6 @@ extension CameraService {
         return newScale
     }
     
-    /// 줌 배율을 초기화합니다.
-    func zoomInitialize() {
-        
-    }
-    
-    
 }
 
 // MARK: - AVCaptureSession 구현

--- a/MC2-OneShot/Domain/Interface/CameraServiceInterface.swift
+++ b/MC2-OneShot/Domain/Interface/CameraServiceInterface.swift
@@ -17,4 +17,6 @@ protocol CameraServiceInterface {
     func toggleFlashMode()
     func generalAngle()
     func wideAngle()
+    func zoom(factor: CGFloat)
+    func zoomInitialize()
 }

--- a/MC2-OneShot/Domain/Interface/CameraServiceInterface.swift
+++ b/MC2-OneShot/Domain/Interface/CameraServiceInterface.swift
@@ -17,6 +17,6 @@ protocol CameraServiceInterface {
     func toggleFlashMode()
     func generalAngle()
     func wideAngle()
-    func zoom(factor: CGFloat)
+    func zoom(currentZoomFactor: CGFloat, delta: CGFloat) -> CGFloat
     func zoomInitialize()
 }

--- a/MC2-OneShot/Domain/Interface/CameraServiceInterface.swift
+++ b/MC2-OneShot/Domain/Interface/CameraServiceInterface.swift
@@ -18,5 +18,4 @@ protocol CameraServiceInterface {
     func generalAngle()
     func wideAngle()
     func zoom(currentZoomFactor: CGFloat, delta: CGFloat) -> CGFloat
-    func zoomInitialize()
 }

--- a/MC2-OneShot/Domain/UseCase/CameraUseCase.swift
+++ b/MC2-OneShot/Domain/UseCase/CameraUseCase.swift
@@ -33,8 +33,8 @@ extension CameraUseCase {
         var isSelfieMode: Bool = false
         var isPhotoDataPrepare: Bool = false
         var photoData: CapturePhoto?
-        var currentZoomFactor: CGFloat = 1.0 //😀
-        var lastScale: CGFloat = 1.0 //😀
+        var currentZoomFactor: CGFloat = 1.0
+        var lastScale: CGFloat = 1.0
     }
 }
 

--- a/MC2-OneShot/Domain/UseCase/CameraUseCase.swift
+++ b/MC2-OneShot/Domain/UseCase/CameraUseCase.swift
@@ -111,10 +111,11 @@ extension CameraUseCase {
     func zoom(factor: CGFloat) {
         let delta = factor / state.lastScale
         state.lastScale = factor
-        
-        let newScale = min(max(state.currentZoomFactor * delta, 1), 5)
-        cameraService.zoom(factor: newScale)
-        state.currentZoomFactor = newScale
+    
+        state.currentZoomFactor = cameraService.zoom(
+            currentZoomFactor: state.currentZoomFactor,
+            delta: delta
+        )
     }
     
     /// 줌 배율을 초기화합니다.

--- a/MC2-OneShot/Domain/UseCase/CameraUseCase.swift
+++ b/MC2-OneShot/Domain/UseCase/CameraUseCase.swift
@@ -33,6 +33,8 @@ extension CameraUseCase {
         var isSelfieMode: Bool = false
         var isPhotoDataPrepare: Bool = false
         var photoData: CapturePhoto?
+        var currentZoomFactor: CGFloat = 1.0 //😀
+        var lastScale: CGFloat = 1.0 //😀
     }
 }
 
@@ -104,4 +106,20 @@ extension CameraUseCase {
     func wideAngle() {
         cameraService.wideAngle()
     }
+    
+    /// 줌 배율을 조절합니다.
+    func zoom(factor: CGFloat) {
+        let delta = factor / state.lastScale
+        state.lastScale = factor
+        
+        let newScale = min(max(state.currentZoomFactor * delta, 1), 5)
+        cameraService.zoom(factor: newScale)
+        state.currentZoomFactor = newScale
+    }
+    
+    /// 줌 배율을 초기화합니다.
+    func zoomInitialize() {
+        state.lastScale = 1.0
+    }
+    
 }

--- a/MC2-OneShot/Presentation/View/MemberCameraView.swift
+++ b/MC2-OneShot/Presentation/View/MemberCameraView.swift
@@ -93,6 +93,15 @@ private struct CameraMiddleView: View {
             .aspectRatio(1, contentMode: .fit)
             .cornerRadius(15)
             .padding(.top, 36)
+            .gesture(
+                MagnifyGesture()
+                    .onChanged { value in
+                        cameraUseCase.zoom(factor: value.magnification)
+                    }
+                    .onEnded { _ in
+                        cameraUseCase.zoomInitialize()
+                    }
+            )
     }
     
     /// 사진 미리보기 뷰

--- a/MC2-OneShot/Presentation/View/PartyCameraView.swift
+++ b/MC2-OneShot/Presentation/View/PartyCameraView.swift
@@ -133,6 +133,15 @@ private struct CameraMiddleView: View {
             .aspectRatio(1, contentMode: .fit)
             .cornerRadius(15)
             .padding(.top, 36)
+            .gesture(
+                MagnificationGesture()
+                    .onChanged { val in
+                        cameraUseCase.zoom(factor: val)
+                    }
+                    .onEnded { _ in
+                        cameraUseCase.zoomInitialize()
+                    }
+            )
     }
     
     /// 사진 미리보기 뷰

--- a/MC2-OneShot/Presentation/View/PartyCameraView.swift
+++ b/MC2-OneShot/Presentation/View/PartyCameraView.swift
@@ -134,9 +134,9 @@ private struct CameraMiddleView: View {
             .cornerRadius(15)
             .padding(.top, 36)
             .gesture(
-                MagnificationGesture()
-                    .onChanged { val in
-                        cameraUseCase.zoom(factor: val)
+                MagnifyGesture()
+                    .onChanged { value in
+                        cameraUseCase.zoom(factor: value.magnification)
                     }
                     .onEnded { _ in
                         cameraUseCase.zoomInitialize()


### PR DESCRIPTION
## Description
광각과 일반 렌즈 각각에 대해 줌 배율을 조절할 수 있도록 수정하였습니다.
일반 렌즈의 최소 배율은 1.0x이고 광각의 최소 배율은 0.5x입니다.
최대 배율은 임의로 정한 적정 선 `maxZoomFactor`까지 가능하도록 설정하였고 필요시 이 값을 수정하면 됩니다.
만약, 하드웨어 상 가능한 최대 배율을 원하면 주석으로 남긴 `activeFormat.videoMaxZoomFactor`을 사용하면 됩니다.

** 추후
일반렌즈 1.0x이하로 줌 배율을 낮출시 광각으로 전환되기 위해선
`virtualDeviceSwitchOverVideoZoomFactors `을 사용해야 될 것으로 추정합니다.

참고로 현재 아이폰 기본 카메라앱과 Locket을 보면,
평소 와이드 앵글(우리의 generalAngle: `.builtInWideAngleCamera`)을 사용하다가
0.5x ~ 1.0x 사이로 배율이 내려가면 망원 렌즈(우리의 wideAngle: `.builtInUltraWideCamera`)로 자동 전환되고,
가끔(?) 3.0x 이상으로 올라가면 아래 사진 상의 '울트라 와이드' 렌즈로 전환됩니다.

![E_20213716_87159](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M10-Sandwich/assets/110075512/5b4df4e6-bc02-4652-b867-280c49818dec)



## Issue
- Resolved: #198
