### PR TITLE
[PR] PartyListView에서 상단 MemberInfo 안겹치는 부분 해결

### DIFF
--- a/MC2-OneShot.xcodeproj/project.pbxproj
+++ b/MC2-OneShot.xcodeproj/project.pbxproj
@@ -654,7 +654,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MC2-OneShot/Preview Content\"";
-				DEVELOPMENT_TEAM = 9XG4S4XZWN;
+				DEVELOPMENT_TEAM = 8U8S6CBZ9D;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "MC2-OneShot/App/Info.plist";
@@ -672,7 +672,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.1.3;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.sandwich.ADA.MC2.OneShot-thinkyside";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sandwich.MC2-OneShot-jongchang";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -692,7 +692,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MC2-OneShot/Preview Content\"";
-				DEVELOPMENT_TEAM = 9XG4S4XZWN;
+				DEVELOPMENT_TEAM = 8U8S6CBZ9D;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "MC2-OneShot/App/Info.plist";
@@ -710,7 +710,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.1.3;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.sandwich.ADA.MC2.OneShot-thinkyside";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sandwich.MC2-OneShot-jongchang";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/MC2-OneShot/Presentation/View/PartyListView.swift
+++ b/MC2-OneShot/Presentation/View/PartyListView.swift
@@ -74,37 +74,39 @@ private struct MemberInfoView: View {
     let party: Party
     
     var body: some View {
-        if (0...3).contains(party.memberList.count) {
-            ForEach(party.memberList.indices, id: \.self) { index in
-                if let image = UIImage(data: party.memberList[index].profileImageData) {
-                    Image(uiImage: image)
-                        .resizable()
-                        .frame (width: 32, height: 32)
-                        .clipShape(Circle())
-                        .padding(.trailing, 24*CGFloat(index))
+        ZStack(alignment: .trailing) {
+            if (0...3).contains(party.memberList.count) {
+                ForEach(party.memberList.indices, id: \.self) { index in
+                    if let image = UIImage(data: party.memberList[index].profileImageData) {
+                        Image(uiImage: image)
+                            .resizable()
+                            .frame (width: 32, height: 32)
+                            .clipShape(Circle())
+                            .padding(.trailing, 24*CGFloat(index))
+                    }
                 }
-            }
-        } else {
-            ForEach(0..<2) { index in
-                if let image = UIImage(data: party.memberList[index].profileImageData) {
-                    Image(uiImage: image)
-                        .resizable()
-                        .frame (width: 32, height: 32)
-                        .clipShape(Circle())
-                        .padding(.trailing, 24*CGFloat(index))
+            } else {
+                ForEach(0..<2) { index in
+                    if let image = UIImage(data: party.memberList[index].profileImageData) {
+                        Image(uiImage: image)
+                            .resizable()
+                            .frame (width: 32, height: 32)
+                            .clipShape(Circle())
+                            .padding(.trailing, 24*CGFloat(index))
+                    }
                 }
-            }
-            
-            ZStack {
-                Circle()
-                    .frame(width: 32)
-                    .foregroundStyle(.shot00)
                 
-                Text("+\(party.memberList.count - 2)")
-                    .pretendard(.semiBold, 17)
-                    .foregroundStyle(.shotC6)
+                ZStack {
+                    Circle()
+                        .frame(width: 32)
+                        .foregroundStyle(.shot00)
+                    
+                    Text("+\(party.memberList.count - 2)")
+                        .pretendard(.semiBold, 17)
+                        .foregroundStyle(.shotC6)
+                }
+                .padding(.trailing, 24 * 2)
             }
-            .padding(.trailing, 24 * 2)
         }
     }
 }


### PR DESCRIPTION
## Description
리팩토링 후 PartyListView의 상단 MemberInfo 동그라미들이 안겹치고 떨어졌던 부분 수정

## Screenshot
<p align="center">
<img src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M10-Sandwich/assets/110075512/0bf89493-88ce-4c29-8042-7e0c7603f10a" height="500">
수정 전 -> 후
<img src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M10-Sandwich/assets/110075512/9f494a0b-df65-45d9-aac8-8a83369bc79a" height="500">
</p>

## Issue
- Resolved: #200
